### PR TITLE
fix: add corsheaders

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -164,5 +165,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
-    "http://127.0.0.1:3000"
+    "http://127.0.0.1:3000",
+    "http://localhost:8080",
+    "http://127.0.0.1:8080"
 ]


### PR DESCRIPTION
## Summary by Sourcery

Enable cross-origin requests by integrating django-cors-headers middleware and updating the allowed origins list

Enhancements:
- Enable CORS by adding corsheaders.middleware.CorsMiddleware
- Expand CORS_ALLOWED_ORIGINS to include ports 3000 and 8080 on localhost and 127.0.0.1