### PR TITLE
fix: replace JWT to read tokens from cookies, not auth headers

### DIFF
--- a/accounts/authentication.py
+++ b/accounts/authentication.py
@@ -1,0 +1,21 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken
+from django.conf import settings
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    
+    def authenticate(self, request): 
+        cookie_name = getattr(settings, 'SIMPLE_JWT', {}).get('AUTH_COOKIE', 'access_token')
+
+        raw_token = request.COOKIES.get(cookie_name)
+        
+        if raw_token is None:
+            # No token in cookie, then not authenticated, return none
+            return None
+        
+        # Validate the token 
+        validated_token = self.get_validated_token(raw_token)
+        
+        # Get user from validated token
+        return self.get_user(validated_token), validated_token

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -18,13 +18,10 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         }
 
     def validate(self,attrs):
-        """Custom validation method.
-        Called after individual field validation
-        """
         if attrs['password'] != attrs['password_confirm']:
             raise serializers.ValidationError("Passwords do not match!")
 
-        attrs.pop('password_confirm', None)    #We remove this since it's not required for user creation
+        attrs.pop('password_confirm', None) 
         return attrs
     
     def validate_email(self, value):
@@ -34,9 +31,6 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
 
     
     def create(self, validated_data):
-        """
-        Create user with hashed password.
-        """
         user = User.objects.create_user(
             username=validated_data['username'],
             email=validated_data['email'],
@@ -49,7 +43,6 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         return user
     
 class UserSerializer(serializers.ModelSerializer):
-    """Used to retrieve and update user data"""
     class Meta:
         model = User
         fields = ['id', 'username', 'email', 'first_name', 'last_name',

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework_simplejwt.views import TokenRefreshView
 from . import views
 
 app_name = 'accounts'
@@ -7,8 +6,9 @@ app_name = 'accounts'
 urlpatterns = [
     #Authenticatication endpoints
     path('auth/register/', views.RegisterView.as_view(), name='register'),
-    path('auth/login/', views.login_view, name='login'),
-    path('auth/token/refresh/',TokenRefreshView.as_view(), name='token_refresh'),
+    path('auth/login/', views.LoginView.as_view(), name='login'),
+     path('auth/logout/', views.LogoutView.as_view(), name='logout'),
+     path('auth/token/refresh/', views.TokenRefreshView.as_view(), name='token_refresh'),
 
     #user profile endpoints
     path('profile/', views.UserProfileView.as_view(), name='profile'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,9 +1,13 @@
 from rest_framework import generics, status, permissions
 from rest_framework.response import Response
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth import get_user_model
 from .serializers import UserRegistrationSerializer, UserSerializer, LoginSerializer
+from rest_framework_simplejwt.views import TokenRefreshView as BaseTokenRefreshView
+from rest_framework_simplejwt.exceptions import InvalidToken
+from django.conf import settings
 
 User = get_user_model()
 
@@ -55,32 +59,152 @@ class RegisterView(generics.CreateAPIView):
             'message': f"{requested_role.title()} account created successfully"
         }, status=status.HTTP_201_CREATED)
     
-@api_view(['POST'])
-@permission_classes([permissions.AllowAny])
-def login_view(request):
+# @api_view(['POST'])
+# @permission_classes([permissions.AllowAny])
+# def login_view(request):
 
-    serializer = LoginSerializer(data=request.data, context={'request':request})
+#     serializer = LoginSerializer(data=request.data, context={'request':request})
 
-    if serializer.is_valid():
+#     if serializer.is_valid():
+#         user = serializer.validated_data['user']
+
+#         #Generate JWT tokens
+#         refresh = RefreshToken.for_user(user)
+
+#         return Response({
+#             'user': UserSerializer(user).data,
+#             'refresh': str(refresh),
+#             'access': str(refresh.access_token)
+#         })
+#     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class LoginView(generics.GenericAPIView):
+    serializer_class = LoginSerializer
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, *args, **kwargs):
+
+        serializer = self.get_serializer(data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        
         user = serializer.validated_data['user']
 
-        #Generate JWT tokens
+        # Generate JWT tokens
         refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        refresh_token = str(refresh)
 
-        return Response({
+        response = Response({
             'user': UserSerializer(user).data,
-            'refresh': str(refresh),
-            'access': str(refresh.access_token)
-        })
-    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            'message': 'Login successful'
+        }, status=status.HTTP_200_OK)
 
+        response.set_cookie(
+            key=settings.SIMPLE_JWT.get('AUTH_COOKIE', 'access_token'),
+            value=access_token,
+            max_age=int(settings.SIMPLE_JWT['ACCESS_TOKEN_LIFETIME'].total_seconds()),
+            secure=settings.SIMPLE_JWT.get('AUTH_COOKIE_SECURE', not settings.DEBUG),
+            httponly=settings.SIMPLE_JWT.get('AUTH_COOKIE_HTTP_ONLY', True),
+            samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
+            path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+        )
+
+        response.set_cookie(
+            key=settings.SIMPLE_JWT.get('AUTH_COOKIE_REFRESH', 'refresh_token'),
+            value=refresh_token,
+            max_age=int(settings.SIMPLE_JWT['REFRESH_TOKEN_LIFETIME'].total_seconds()),
+            secure=settings.SIMPLE_JWT.get('AUTH_COOKIE_SECURE', not settings.DEBUG),
+            httponly=settings.SIMPLE_JWT.get('AUTH_COOKIE_HTTP_ONLY', True),
+            samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
+            path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+        )
+
+        return response
+
+class LogoutView(generics.GenericAPIView):
+    """ 
+    Since tokens are stored in httpOnly cookies, JavaScript cannot delete them.
+    This endpoint instructs the browser to delete the cookies by setting them
+    with empty values and past expiry dates.
+    """
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        
+        response = Response({
+            'message': 'Logout successful'
+        }, status=status.HTTP_200_OK)
+
+        # Clear access token cookie
+        response.delete_cookie(
+            key=settings.SIMPLE_JWT.get('AUTH_COOKIE', 'access_token'),
+            path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+            samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
+        )
+
+        # Clear refresh token cookie
+        response.delete_cookie(
+            key=settings.SIMPLE_JWT.get('AUTH_COOKIE_REFRESH', 'refresh_token'),
+            path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+            samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
+        )
+
+        return response    
+        
 class UserProfileView(generics.RetrieveUpdateAPIView):
-    """
-    View and update user profile
-    """
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):
-        #return the current user
-        return self.request.user   
+        return self.request.user
+
+class TokenRefreshView(BaseTokenRefreshView):
+    
+    def post(self, request, *args, **kwargs):
+        
+        refresh_token = request.COOKIES.get(
+            settings.SIMPLE_JWT.get('AUTH_COOKIE_REFRESH', 'refresh_token')
+        )
+        
+        if refresh_token is None:
+            return Response({
+                'error': 'Refresh token not found in cookies'
+            }, status=status.HTTP_401_UNAUTHORIZED)
+        
+        # Add refresh token to request data
+        request.data['refresh'] = refresh_token
+        
+        response = super().post(request, *args, **kwargs)
+        
+        if response.status_code == 200:
+            # Extract new access token from response
+            access_token = response.data.get('access')
+            new_response = Response({
+                'message': 'Token refreshed successfully'
+            }, status=status.HTTP_200_OK)
+
+            new_response.set_cookie(
+                key=settings.SIMPLE_JWT.get('AUTH_COOKIE', 'access_token'),
+                value=access_token,
+                max_age=int(settings.SIMPLE_JWT['ACCESS_TOKEN_LIFETIME'].total_seconds()),
+                secure=settings.SIMPLE_JWT.get('AUTH_COOKIE_SECURE', not settings.DEBUG),
+                httponly=settings.SIMPLE_JWT.get('AUTH_COOKIE_HTTP_ONLY', True),
+                samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
+                path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+            )
+            
+            if 'refresh' in response.data:
+                new_refresh_token = response.data.get('refresh')
+                new_response.set_cookie(
+                    key=settings.SIMPLE_JWT.get('AUTH_COOKIE_REFRESH', 'refresh_token'),
+                    value=new_refresh_token,
+                    max_age=int(settings.SIMPLE_JWT['REFRESH_TOKEN_LIFETIME'].total_seconds()),
+                    secure=settings.SIMPLE_JWT.get('AUTH_COOKIE_SECURE', not settings.DEBUG),
+                    httponly=settings.SIMPLE_JWT.get('AUTH_COOKIE_HTTP_ONLY', True),
+                    samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
+                    path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+                )
+            
+            return new_response
+        
+        return response       

--- a/config/settings.py
+++ b/config/settings.py
@@ -103,6 +103,7 @@ DATABASES = {
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'accounts.authentication.CookieJWTAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
@@ -116,12 +117,21 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
-    'ROTATE_REFRESH_TOKENS': True,
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+    # Auth
+    # "AUTH_HEADER_TYPES": ("Bearer",),
+    # Auth Cookie
+    "AUTH_COOKIE_ACCESS": "access_token",
+    "AUTH_COOKIE_REFRESH": "refresh_token",
+    "AUTH_COOKIE_DOMAIN": None,  # ".example.com" or None for standard domain cookie
+    "AUTH_COOKIE_SECURE": not DEBUG, #  cookies only sent over HTTPS in production, but work on HTTP in development
+    "AUTH_COOKIE_HTTP_ONLY": True,
+    "AUTH_COOKIE_SAMESITE": "Lax",  
+    # "AUTH_COOKIE_REFRESH_PATH": "/accounts/auth/",
 }
 
-
+ 
 # Password validation
 # https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators
 
@@ -169,3 +179,5 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:8080",
     "http://127.0.0.1:8080"
 ]
+
+CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
## Summary by Sourcery

Switch JWT handling to use cookies instead of headers by introducing cookie-based authentication views, a custom authentication class, and updating related settings and routes

New Features:
- Add LoginView to generate JWT tokens and set them in secure HTTP-only cookies
- Add LogoutView to clear JWT cookies upon user logout
- Add TokenRefreshView to refresh JWT tokens from cookies and update cookies accordingly
- Introduce CookieJWTAuthentication to authenticate users using JWTs stored in cookies

Bug Fixes:
- Retrieve JWT tokens from cookies instead of authorization headers

Enhancements:
- Configure SIMPLE_JWT settings for cookie names, lifetimes, and security flags
- Update REST framework authentication to include CookieJWTAuthentication
- Reduce access token lifetime from 60 minutes to 15 minutes

Chores:
- Update URL routes to use the new cookie-based authentication views
- Remove outdated login_view function and clean up serializer comments