### PR TITLE
fix:inconsistent cookie name && add domain settings to logout view

### DIFF
--- a/accounts/authentication.py
+++ b/accounts/authentication.py
@@ -6,7 +6,7 @@ from django.conf import settings
 class CookieJWTAuthentication(JWTAuthentication):
     
     def authenticate(self, request): 
-        cookie_name = getattr(settings, 'SIMPLE_JWT', {}).get('AUTH_COOKIE', 'access_token')
+        cookie_name = getattr(settings, 'SIMPLE_JWT', {}).get('AUTH_COOKIE_ACCESS', 'access_token')
 
         raw_token = request.COOKIES.get(cookie_name)
         

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -139,6 +139,7 @@ class LogoutView(generics.GenericAPIView):
         response.delete_cookie(
             key=settings.SIMPLE_JWT.get('AUTH_COOKIE', 'access_token'),
             path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+             domain=settings.SIMPLE_JWT.get('AUTH_COOKIE_DOMAIN', None),
             samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
         )
 
@@ -146,6 +147,7 @@ class LogoutView(generics.GenericAPIView):
         response.delete_cookie(
             key=settings.SIMPLE_JWT.get('AUTH_COOKIE_REFRESH', 'refresh_token'),
             path=settings.SIMPLE_JWT.get('AUTH_COOKIE_PATH', '/'),
+             domain=settings.SIMPLE_JWT.get('AUTH_COOKIE_DOMAIN', None),
             samesite=settings.SIMPLE_JWT.get('AUTH_COOKIE_SAMESITE', 'Lax'),
         )
 


### PR DESCRIPTION
## Summary by Sourcery

Fix inconsistent JWT cookie naming and add domain support when deleting auth cookies in logout view

Bug Fixes:
- Use the AUTH_COOKIE_ACCESS setting instead of AUTH_COOKIE for access token retrieval

Enhancements:
- Include the domain parameter from settings when deleting access and refresh cookies in the logout view